### PR TITLE
[feat] 관리자-신고페이지 구현 완료

### DIFF
--- a/my-local-diary/public/json/db.json
+++ b/my-local-diary/public/json/db.json
@@ -1264,7 +1264,7 @@
       "content": "이 게시글은 부적절한 내용을 포함하고 있습니다.",
       "status": "처리중",
       "member_id": 3,
-      "report_reason_id": "5"
+      "report_reason_id": "10"
     },
     {
       "id": "2",
@@ -1305,6 +1305,57 @@
       "status": "처리중",
       "member_id": 14,
       "report_reason_id": 9
+    },
+    {
+      "id": 6,
+      "created_at": "2025.04.18",
+      "report_type": "댓글",
+      "reported_id": 18,
+      "content": "사기성 댓글입니다.",
+      "status": "처리중",
+      "member_id": 17,
+      "report_reason_id": 6
+    },
+    {
+      "id": 7,
+      "created_at": "2025.04.20",
+      "report_type": "회원",
+      "reported_id": 21,
+      "content": "자살 유도 발언이 있습니다.",
+      "status": "처리중",
+      "member_id": 23,
+      "report_reason_id": 7
+    },
+    {
+      "id": 8,
+      "created_at": "2025.04.21",
+      "report_type": "게시글",
+      "reported_id": 25,
+      "content": "폭력적인 게시글입니다.",
+      "status": "반려",
+      "member_id": 31,
+      "report_reason_id": 8
+    },
+    {
+      "id": 9,
+      "created_at": "2025.04.22",
+      "report_type": "댓글",
+      "reported_id": 30,
+      "content": "광고성 댓글입니다.",
+      "status": "처리완료",
+      "member_id": 28,
+      "report_reason_id": 1
+    },
+    {
+      "id": 10,
+      "created_at": "2025.04.25",
+      "report_type": "게시글",
+      "reported_id": 32,
+      "content": "기타 신고 사유로 직접 입력했습니다.",
+      "status": "처리중",
+      "member_id": 33,
+      "report_reason_id": 10,
+      "custom_reason": "이상한 링크를 지속적으로 올림"
     }
   ],
   "report_reasons": [
@@ -1346,7 +1397,7 @@
     },
     {
       "id": "10",
-      "reason": "기타 (직접 입력)"
+      "reason": "기타"
     }
   ]
 }

--- a/my-local-diary/public/json/db.json
+++ b/my-local-diary/public/json/db.json
@@ -1,1243 +1,1352 @@
 {
-    "members": [
-        {
-            "id": "1",
-            "login_id": "test01",
-            "password": "pass01",
-            "email": "test01@example.com",
-            "name": "권응애",
-            "birth": "1997-11-11",
-            "nickname": "유저01",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "여행 좋아",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/aespa - Supernova.mp3"
-        },
-        {
-            "id": "2",
-            "login_id": "test02",
-            "password": "pass02",
-            "email": "test02@example.com",
-            "name": "한콜콜",
-            "birth": "1999-02-11",
-            "nickname": "관리자01",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "근엄 관리자",
-            "role": "ADMIN",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/aespa - Armageddon.mp3"
-        },
-        {
-            "id": "3",
-            "login_id": "test03",
-            "password": "pass03",
-            "email": "test03@example.com",
-            "name": "정한동",
-            "birth": "2000-02-11",
-            "nickname": "유저02",
-            "status": "SUSPENDED",
-            "is_public": "TRUE",
-            "bio": "정지 에반데",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": null
-        },
-        {
-            "id": "4",
-            "login_id": "test04",
-            "password": "pass04",
-            "email": "test04@example.com",
-            "name": "프시원",
-            "birth": "2000-02-11",
-            "nickname": "유저03",
-            "status": "ACTIVE",
-            "is_public": "FALSE",
-            "bio": "공개는 부끄렁",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/아일릿 - Lucky Girl Syndrome.flac"
-        },
-        {
-            "id": "5",
-            "login_id": "test05",
-            "password": "pass05",
-            "email": "test05@example.com",
-            "name": "사륜안",
-            "birth": "1995-02-11",
-            "nickname": "Madara Uchiha",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "role": "MEMBER",
-            "profile_image": "/images/profile/profile.png",
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/잔나비 (JANNABI) - 주저하는 연인들을 위해.mp3"
-        },
-        {
-            "id": "6",
-            "login_id": "test06",
-            "password": "pass06",
-            "email": "test06@example.com",
-            "name": "이혜롱",
-            "birth": "2002-02-11",
-            "nickname": "유저06",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "하이여",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/tws (투어스)-첫 만남은 계획대로 되지 않아.mp3"
-        },
-        {
-            "id": "7",
-            "login_id": "test07",
-            "password": "pass07",
-            "email": "test07@example.com",
-            "name": "정선민",
-            "birth": "2002-05-11",
-            "nickname": "유저07",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "석현님 커피 왜 안사줌",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/박재범 - 좋아 (JOAH).mp3"
-        },
-        {
-            "id": "8",
-            "login_id": "test08",
-            "password": "pass08",
-            "email": "test08@example.com",
-            "name": "동한정",
-            "birth": "2000-05-11",
-            "nickname": "유저08",
-            "status": "ACTIVE",
-            "is_public": "TRUE",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "role": "MEMBER",
-            "profile_image": null,
-            "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/Freestyle - Y.mp3"
-        }
-    ],
-    "post": [
-        {
-            "id": 1,
-            "title": "서울 종로 서순라길 산책 코스",
-            "post": "종로의 고즈넉한 서순라길부터 청계천, 광화문까지 산책하며 여유를 즐긴 하루.",
-            "diary": "근데 사람 개많음 진짜 인류애 떨어짐",
-            "created_at": "2025-04-23T10:30:00",
-            "updated_at": "2025-04-23T11:15:00",
-            "likes_count": 12,
-            "member_id": 1,
-            "photos": [
-                {
-                    "id": 1,
-                    "image_url": "https://example.com/photos/seosulla_street.jpg",
-                    "orders": 1
-                },
-                {
-                    "id": 2,
-                    "image_url": "https://example.com/photos/artisan_bakery.jpg",
-                    "orders": 2
-                },
-                {
-                    "id": 3,
-                    "image_url": "https://example.com/photos/cheonggyecheon_stream.jpg",
-                    "orders": 3
-                },
-                {
-                    "id": 4,
-                    "image_url": "https://example.com/photos/kyobo_gwanghwamun.jpg",
-                    "orders": 4
-                }
-            ],
-            "places": [
-                {
-                    "id": 1,
-                    "name": "서순라길 산책로",
-                    "latitude": 37.5704,
-                    "longitude": 126.9958,
-                    "orders": 1,
-                    "thumbnail_image": "https://example.com/places/seosulla.jpg",
-                    "post_id": 1
-                },
-                {
-                    "id": 2,
-                    "name": "아티장 베이커리",
-                    "latitude": 37.5710,
-                    "longitude": 126.9945,
-                    "orders": 2,
-                    "thumbnail_image": "https://example.com/places/artisan.jpg",
-                    "post_id": 1
-                },
-                {
-                    "id": 3,
-                    "name": "청계천",
-                    "latitude": 37.5685,
-                    "longitude": 126.9976,
-                    "orders": 3,
-                    "thumbnail_image": "https://example.com/places/cheonggyecheon.jpg",
-                    "post_id": 1
-                },
-                {
-                    "id": 4,
-                    "name": "광화문 교보문고",
-                    "latitude": 37.5700,
-                    "longitude": 126.9769,
-                    "orders": 4,
-                    "thumbnail_image": "https://example.com/places/kyobo.jpg",
-                    "post_id": 1
-                }
-            ],
-            "comments": [
-                {
-                    "id": "1",
-                    "content": "오늘 하루가 너무 이쁜 하루시네요!",
-                    "created_at": "2025-04-23T10:30:00",
-                    "updated_at": null,
-                    "post_id": "1"
-                },
-                {
-                    "id": 2,
-                    "content": "사람 너무 많지 않아요? 저번에 갔을 땐 북적북적...",
-                    "created_at": "2025-04-23T12:12:00",
-                    "updated_at": "2025-04-23T12:12:00",
-                    "member_id": 5,
-                    "parent_comment_id": null,
-                    "is_deleted": false
-                },
-                {
-                    "id": 3,
-                    "content": "맞아요 ㅋㅋㅋㅋ 저도 인류애 시험 받았어요",
-                    "created_at": "2025-04-23T12:15:00",
-                    "updated_at": "2025-04-23T12:15:00",
-                    "member_id": 4,
-                    "parent_comment_id": 2,
-                    "is_deleted": false
-                }
-            ],
-            "likes": [
-                {
-                    "id": 1,
-                    "created_at": "2025-04-23T12:00:00",
-                    "member_id": 2,
-                    "type": "POST"
-                },
-                {
-                    "id": 2,
-                    "created_at": "2025-04-23T12:02:00",
-                    "member_id": 7,
-                    "type": "POST"
-                },
-                {
-                    "id": 3,
-                    "created_at": "2025-04-23T12:03:00",
-                    "member_id": 4,
-                    "type": "POST"
-                },
-                {
-                    "id": 4,
-                    "created_at": "2025-04-23T12:05:00",
-                    "member_id": 5,
-                    "type": "POST"
-                },
-                {
-                    "id": 5,
-                    "created_at": "2025-04-23T12:08:00",
-                    "member_id": 6,
-                    "type": "POST"
-                },
-                {
-                    "id": 6,
-                    "created_at": "2025-04-23T12:20:00",
-                    "member_id": 5,
-                    "type": "COMMENT",
-                    "target_id": 1
-                },
-                {
-                    "id": 7,
-                    "created_at": "2025-04-23T12:21:00",
-                    "member_id": 6,
-                    "type": "COMMENT",
-                    "target_id": 2
-                },
-                {
-                    "id": 8,
-                    "created_at": "2025-04-23T12:22:00",
-                    "member_id": 7,
-                    "type": "COMMENT",
-                    "target_id": 2
-                }
-            ]
-        }
-    ],
-    "follow": [
-        {
-            "id": "1",
-            "following_member_id": "1",
-            "follower_target_member_id": "8",
-            "status": null,
-            "following_member": {
-                "id": "1",
-                "nickname": "유저01",
-                "status": "ACTIVE",
-                "bio": "여행 좋아",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "2",
-            "following_member_id": "4",
-            "follower_target_member_id": "8",
-            "status": null,
-            "following_member": {
-                "id": "4",
-                "nickname": "유저04",
-                "status": "ACTIVE",
-                "bio": "공개는 부끄렁",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "3",
-            "following_member_id": "5",
-            "follower_target_member_id": "8",
-            "status": null,
-            "following_member": {
-                "id": "5",
-                "nickname": "Madara Uchiha",
-                "status": "ACTIVE",
-                "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-                "role": "MEMBER",
-                "profile_image": "/images/profile/profile.png"
-            },
-            "follower_target_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "4",
-            "following_member_id": "6",
-            "follower_target_member_id": "8",
-            "status": null,
-            "following_member": {
-                "id": "6",
-                "nickname": "유저06",
-                "status": "ACTIVE",
-                "is_public": "TRUE",
-                "bio": "하이여",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "5",
-            "following_member_id": "7",
-            "follower_target_member_id": "8",
-            "status": null,
-            "following_member": {
-                "id": "7",
-                "nickname": "유저07",
-                "status": "ACTIVE",
-                "bio": "석현님 커피 왜 안사줌",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "6",
-            "following_member_id": "8",
-            "follower_target_member_id": "1",
-            "status": null,
-            "following_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "1",
-                "nickname": "유저01",
-                "status": "ACTIVE",
-                "bio": "여행 좋아",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "7",
-            "following_member_id": "8",
-            "follower_target_member_id": "4",
-            "status": null,
-            "following_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "4",
-                "nickname": "유저04",
-                "status": "ACTIVE",
-                "bio": "공개는 부끄렁",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "8",
-            "following_member_id": "8",
-            "follower_target_member_id": "5",
-            "status": null,
-            "following_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "5",
-                "nickname": "Madara Uchiha",
-                "status": "ACTIVE",
-                "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-                "role": "MEMBER",
-                "profile_image": "/images/profile/profile.png"
-            }
-        },
-        {
-            "id": "9",
-            "following_member_id": "8",
-            "follower_target_member_id": "6",
-            "status": null,
-            "following_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "6",
-                "nickname": "유저06",
-                "status": "ACTIVE",
-                "bio": "하이여",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        },
-        {
-            "id": "10",
-            "following_member_id": "8",
-            "follower_target_member_id": "7",
-            "status": null,
-            "following_member": {
-                "id": "8",
-                "nickname": "유저08",
-                "status": "ACTIVE",
-                "bio": "집에 있지만 집에 가고 싶다.",
-                "role": "MEMBER",
-                "profile_image": null
-            },
-            "follower_target_member": {
-                "id": "7",
-                "nickname": "유저07",
-                "status": "ACTIVE",
-                "bio": "석현님 커피 왜 안사줌",
-                "role": "MEMBER",
-                "profile_image": null
-            }
-        }
-    ],
-    "member_stamp":[
+  "members": [
+    {
+      "id": "1",
+      "login_id": "test01",
+      "password": "pass01",
+      "email": "test01@example.com",
+      "name": "권응애",
+      "birth": "1997-11-11",
+      "nickname": "유저01",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "여행 좋아",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/aespa - Supernova.mp3"
+    },
+    {
+      "id": "2",
+      "login_id": "test02",
+      "password": "pass02",
+      "email": "test02@example.com",
+      "name": "한콜콜",
+      "birth": "1999-02-11",
+      "nickname": "관리자01",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "근엄 관리자",
+      "role": "ADMIN",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/aespa - Armageddon.mp3"
+    },
+    {
+      "id": "3",
+      "login_id": "test03",
+      "password": "pass03",
+      "email": "test03@example.com",
+      "name": "정한동",
+      "birth": "2000-02-11",
+      "nickname": "유저02",
+      "status": "SUSPENDED",
+      "is_public": "TRUE",
+      "bio": "정지 에반데",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": null
+    },
+    {
+      "id": "4",
+      "login_id": "test04",
+      "password": "pass04",
+      "email": "test04@example.com",
+      "name": "프시원",
+      "birth": "2000-02-11",
+      "nickname": "유저03",
+      "status": "ACTIVE",
+      "is_public": "FALSE",
+      "bio": "공개는 부끄렁",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/아일릿 - Lucky Girl Syndrome.flac"
+    },
+    {
+      "id": "5",
+      "login_id": "test05",
+      "password": "pass05",
+      "email": "test05@example.com",
+      "name": "사륜안",
+      "birth": "1995-02-11",
+      "nickname": "Madara Uchiha",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+      "role": "MEMBER",
+      "profile_image": "/images/profile/profile.png",
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/잔나비 (JANNABI) - 주저하는 연인들을 위해.mp3"
+    },
+    {
+      "id": "6",
+      "login_id": "test06",
+      "password": "pass06",
+      "email": "test06@example.com",
+      "name": "이혜롱",
+      "birth": "2002-02-11",
+      "nickname": "유저06",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "하이여",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/tws (투어스)-첫 만남은 계획대로 되지 않아.mp3"
+    },
+    {
+      "id": "7",
+      "login_id": "test07",
+      "password": "pass07",
+      "email": "test07@example.com",
+      "name": "정선민",
+      "birth": "2002-05-11",
+      "nickname": "유저07",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "석현님 커피 왜 안사줌",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/박재범 - 좋아 (JOAH).mp3"
+    },
+    {
+      "id": "8",
+      "login_id": "test08",
+      "password": "pass08",
+      "email": "test08@example.com",
+      "name": "동한정",
+      "birth": "2000-05-11",
+      "nickname": "유저08",
+      "status": "ACTIVE",
+      "is_public": "TRUE",
+      "bio": "집에 있지만 집에 가고 싶다.",
+      "role": "MEMBER",
+      "profile_image": null,
+      "profile_music": "https://rococo-cocada-2c23e0.netlify.app/audio/Freestyle - Y.mp3"
+    }
+  ],
+  "post": [
+    {
+      "id": "1",
+      "title": "서울 종로 서순라길 산책 코스",
+      "post": "종로의 고즈넉한 서순라길부터 청계천, 광화문까지 산책하며 여유를 즐긴 하루.",
+      "diary": "근데 사람 개많음 진짜 인류애 떨어짐",
+      "created_at": "2025-04-23T10:30:00",
+      "updated_at": "2025-04-23T11:15:00",
+      "likes_count": 12,
+      "member_id": 1,
+      "photos": [
         {
           "id": 1,
-          "achieved_date": "2025-04-10",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
+          "image_url": "https://example.com/photos/seosulla_street.jpg",
+          "orders": 1
         },
         {
           "id": 2,
-          "achieved_date": "2025-04-11",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
+          "image_url": "https://example.com/photos/artisan_bakery.jpg",
+          "orders": 2
         },
         {
           "id": 3,
-          "achieved_date": "2025-04-12",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
+          "image_url": "https://example.com/photos/cheonggyecheon_stream.jpg",
+          "orders": 3
         },
         {
           "id": 4,
-          "achieved_date": "2025-04-13",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
+          "image_url": "https://example.com/photos/kyobo_gwanghwamun.jpg",
+          "orders": 4
+        }
+      ],
+      "places": [
+        {
+          "id": 1,
+          "name": "서순라길 산책로",
+          "latitude": 37.5704,
+          "longitude": 126.9958,
+          "orders": 1,
+          "thumbnail_image": "https://example.com/places/seosulla.jpg",
+          "post_id": 1
+        },
+        {
+          "id": 2,
+          "name": "아티장 베이커리",
+          "latitude": 37.571,
+          "longitude": 126.9945,
+          "orders": 2,
+          "thumbnail_image": "https://example.com/places/artisan.jpg",
+          "post_id": 1
+        },
+        {
+          "id": 3,
+          "name": "청계천",
+          "latitude": 37.5685,
+          "longitude": 126.9976,
+          "orders": 3,
+          "thumbnail_image": "https://example.com/places/cheonggyecheon.jpg",
+          "post_id": 1
+        },
+        {
+          "id": 4,
+          "name": "광화문 교보문고",
+          "latitude": 37.57,
+          "longitude": 126.9769,
+          "orders": 4,
+          "thumbnail_image": "https://example.com/places/kyobo.jpg",
+          "post_id": 1
+        }
+      ],
+      "comments": [
+        {
+          "id": "1",
+          "content": "오늘 하루가 너무 이쁜 하루시네요!",
+          "created_at": "2025-04-23T10:30:00",
+          "updated_at": null,
+          "post_id": "1"
+        },
+        {
+          "id": 2,
+          "content": "사람 너무 많지 않아요? 저번에 갔을 땐 북적북적...",
+          "created_at": "2025-04-23T12:12:00",
+          "updated_at": "2025-04-23T12:12:00",
+          "member_id": 5,
+          "parent_comment_id": null,
+          "is_deleted": false
+        },
+        {
+          "id": 3,
+          "content": "맞아요 ㅋㅋㅋㅋ 저도 인류애 시험 받았어요",
+          "created_at": "2025-04-23T12:15:00",
+          "updated_at": "2025-04-23T12:15:00",
+          "member_id": 4,
+          "parent_comment_id": 2,
+          "is_deleted": false
+        }
+      ],
+      "likes": [
+        {
+          "id": 1,
+          "created_at": "2025-04-23T12:00:00",
+          "member_id": 2,
+          "type": "POST"
+        },
+        {
+          "id": 2,
+          "created_at": "2025-04-23T12:02:00",
+          "member_id": 7,
+          "type": "POST"
+        },
+        {
+          "id": 3,
+          "created_at": "2025-04-23T12:03:00",
+          "member_id": 4,
+          "type": "POST"
+        },
+        {
+          "id": 4,
+          "created_at": "2025-04-23T12:05:00",
+          "member_id": 5,
+          "type": "POST"
         },
         {
           "id": 5,
-          "achieved_date": "2025-04-14",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
+          "created_at": "2025-04-23T12:08:00",
+          "member_id": 6,
+          "type": "POST"
         },
         {
           "id": 6,
-          "achieved_date": "2025-04-15",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
+          "created_at": "2025-04-23T12:20:00",
+          "member_id": 5,
+          "type": "COMMENT",
+          "target_id": 1
         },
         {
           "id": 7,
-          "achieved_date": "2025-04-16",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
+          "created_at": "2025-04-23T12:21:00",
+          "member_id": 6,
+          "type": "COMMENT",
+          "target_id": 2
         },
         {
           "id": 8,
-          "achieved_date": "2025-04-17",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 9,
-          "achieved_date": "2025-04-18",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 10,
-          "achieved_date": "2025-04-19",
-          "member": {
-            "id": 8,
-            "nickname": "유저08",
-            "bio": "집에 있지만 집에 가고 싶다.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": null
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
-        },
-        {
-          "id": 11,
-          "achieved_date": "2025-04-20",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
-        },
-        {
-          "id": 12,
-          "achieved_date": "2025-04-21",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
-        },
-        {
-          "id": 13,
-          "achieved_date": "2025-04-22",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
-        },
-        {
-          "id": 14,
-          "achieved_date": "2025-04-23",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
-        },
-        {
-          "id": 15,
-          "achieved_date": "2025-04-24",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "카페냥",
-            "description": "/images/stamp_pic/카페냥"
-          }
-        },
-        {
-          "id": 16,
-          "achieved_date": "2025-04-25",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 17,
-          "achieved_date": "2025-04-26",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 18,
-          "achieved_date": "2025-04-27",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 19,
-          "achieved_date": "2025-04-28",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 20,
-          "achieved_date": "2025-04-29",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "산책냥",
-            "description": "/images/stamp_pic/산책냥"
-          }
-        },
-        {
-          "id": 21,
-          "achieved_date": "2025-04-30",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 22,
-          "achieved_date": "2025-04-01",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 23,
-          "achieved_date": "2025-04-02",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 24,
-          "achieved_date": "2025-04-03",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 25,
-          "achieved_date": "2025-04-04",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "꽐라냥",
-            "description": "/images/stamp_pic/꽐라냥"
-          }
-        },
-        {
-          "id": 26,
-          "achieved_date": "2025-04-05",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
-        },
-        {
-          "id": 27,
-          "achieved_date": "2025-04-06",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
-        },
-        {
-          "id": 28,
-          "achieved_date": "2025-04-07",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
-        },
-        {
-          "id": 29,
-          "achieved_date": "2025-04-08",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
-        },
-        {
-          "id": 30,
-          "achieved_date": "2025-04-09",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "독서냥",
-            "description": "/images/stamp_pic/독서냥"
-          }
-        },
-        {
-          "id": 31,
-          "achieved_date": "2025-04-10",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
-        },
-        {
-          "id": 32,
-          "achieved_date": "2025-04-11",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
-        },
-        {
-          "id": 33,
-          "achieved_date": "2025-04-12",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
-        },
-        {
-          "id": 34,
-          "achieved_date": "2025-04-13",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "영화냥",
-            "description": "/images/stamp_pic/영화냥"
-          }
-        },
-        {
-          "id": 35,
-          "achieved_date": "2025-04-14",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
-        },
-        {
-          "id": 36,
-          "achieved_date": "2025-04-15",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
-        },
-        {
-          "id": 37,
-          "achieved_date": "2025-04-16",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
-        },
-        {
-          "id": 38,
-          "achieved_date": "2025-04-17",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
-        },
-        {
-          "id": 39,
-          "achieved_date": "2025-04-18",
-          "member": {
-            "id": 5,
-            "nickname": "Madara Uchiha",
-            "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
-            "is_public": "TRUE",
-            "status": "ACTIVE",
-            "profile_image": "/images/profile/profile.png"
-          },
-          "stamp": {
-            "id": 1,
-            "name": "맛집냥",
-            "description": "/images/stamp_pic/맛집냥"
-          }
-        }
-      ],
-      "badge": [
-        {
-          "id": 1,
-          "name": "카페인냥",
-          "description": "카페냥 뱃지입니다."
-        },
-        {
-          "id": 2,
-          "name": "산책냥",
-          "description": "산책냥 뱃지입니다."
-        },
-        {
-          "id": 3,
-          "name": "꽐라냥",
-          "description": "꽐라냥 뱃지입니다."
-        },
-        {
-          "id": 4,
-          "name": "독서냥",
-          "description": "독서냥 뱃지입니다."
-        },
-        {
-          "id": 5,
-          "name": "맛집냥",
-          "description": "맛집냥 뱃지입니다."
-        },
-        {
-          "id": 6,
-          "name": "영화냥",
-          "description": "영화냥 뱃지입니다."
-        }
-      ],
-      "member_badge": [
-        {
-          "id": 1,
-          "achived_date": "2025-04-25",
-          "badge_id": 1,
-          "member_id": 5
-        },
-        {
-          "id": 2,
-          "achived_date": "2025-04-25",
-          "badge_id": 2,
-          "member_id": 5
-        },
-        {
-          "id": 3,
-          "achived_date": "2025-04-26",
-          "badge_id": 3,
-          "member_id": 5
-        },
-        {
-          "id": 4,
-          "achived_date": "2025-04-26",
-          "badge_id": 4,
-          "member_id": 5
-        },
-        {
-          "id": 5,
-          "achived_date": "2025-04-27",
-          "badge_id": 5,
-          "member_id": 5
+          "created_at": "2025-04-23T12:22:00",
+          "member_id": 7,
+          "type": "COMMENT",
+          "target_id": 2
         }
       ]
-      ,
-      "today-diary": [
+    }
+  ],
+  "follow": [
+    {
+      "id": "1",
+      "following_member_id": "1",
+      "follower_target_member_id": "8",
+      "status": null,
+      "following_member": {
+        "id": "1",
+        "nickname": "유저01",
+        "status": "ACTIVE",
+        "bio": "여행 좋아",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "2",
+      "following_member_id": "4",
+      "follower_target_member_id": "8",
+      "status": null,
+      "following_member": {
+        "id": "4",
+        "nickname": "유저04",
+        "status": "ACTIVE",
+        "bio": "공개는 부끄렁",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "3",
+      "following_member_id": "5",
+      "follower_target_member_id": "8",
+      "status": null,
+      "following_member": {
+        "id": "5",
+        "nickname": "Madara Uchiha",
+        "status": "ACTIVE",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "role": "MEMBER",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "follower_target_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "4",
+      "following_member_id": "6",
+      "follower_target_member_id": "8",
+      "status": null,
+      "following_member": {
+        "id": "6",
+        "nickname": "유저06",
+        "status": "ACTIVE",
+        "is_public": "TRUE",
+        "bio": "하이여",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "5",
+      "following_member_id": "7",
+      "follower_target_member_id": "8",
+      "status": null,
+      "following_member": {
+        "id": "7",
+        "nickname": "유저07",
+        "status": "ACTIVE",
+        "bio": "석현님 커피 왜 안사줌",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "6",
+      "following_member_id": "8",
+      "follower_target_member_id": "1",
+      "status": null,
+      "following_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "1",
+        "nickname": "유저01",
+        "status": "ACTIVE",
+        "bio": "여행 좋아",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "7",
+      "following_member_id": "8",
+      "follower_target_member_id": "4",
+      "status": null,
+      "following_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "4",
+        "nickname": "유저04",
+        "status": "ACTIVE",
+        "bio": "공개는 부끄렁",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "8",
+      "following_member_id": "8",
+      "follower_target_member_id": "5",
+      "status": null,
+      "following_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "5",
+        "nickname": "Madara Uchiha",
+        "status": "ACTIVE",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "role": "MEMBER",
+        "profile_image": "/images/profile/profile.png"
+      }
+    },
+    {
+      "id": "9",
+      "following_member_id": "8",
+      "follower_target_member_id": "6",
+      "status": null,
+      "following_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "6",
+        "nickname": "유저06",
+        "status": "ACTIVE",
+        "bio": "하이여",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    },
+    {
+      "id": "10",
+      "following_member_id": "8",
+      "follower_target_member_id": "7",
+      "status": null,
+      "following_member": {
+        "id": "8",
+        "nickname": "유저08",
+        "status": "ACTIVE",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "role": "MEMBER",
+        "profile_image": null
+      },
+      "follower_target_member": {
+        "id": "7",
+        "nickname": "유저07",
+        "status": "ACTIVE",
+        "bio": "석현님 커피 왜 안사줌",
+        "role": "MEMBER",
+        "profile_image": null
+      }
+    }
+  ],
+  "member_stamp": [
+    {
+      "id": "1",
+      "achieved_date": "2025-04-10",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "2",
+      "achieved_date": "2025-04-11",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "3",
+      "achieved_date": "2025-04-12",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "4",
+      "achieved_date": "2025-04-13",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "5",
+      "achieved_date": "2025-04-14",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    },
+    {
+      "id": "6",
+      "achieved_date": "2025-04-15",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "7",
+      "achieved_date": "2025-04-16",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "8",
+      "achieved_date": "2025-04-17",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "9",
+      "achieved_date": "2025-04-18",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "10",
+      "achieved_date": "2025-04-19",
+      "member": {
+        "id": 8,
+        "nickname": "유저08",
+        "bio": "집에 있지만 집에 가고 싶다.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": null
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "11",
+      "achieved_date": "2025-04-20",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "12",
+      "achieved_date": "2025-04-21",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "13",
+      "achieved_date": "2025-04-22",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "14",
+      "achieved_date": "2025-04-23",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "15",
+      "achieved_date": "2025-04-24",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "카페냥",
+        "description": "/images/stamp_pic/카페냥"
+      }
+    },
+    {
+      "id": "16",
+      "achieved_date": "2025-04-25",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "17",
+      "achieved_date": "2025-04-26",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "18",
+      "achieved_date": "2025-04-27",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "19",
+      "achieved_date": "2025-04-28",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "20",
+      "achieved_date": "2025-04-29",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "산책냥",
+        "description": "/images/stamp_pic/산책냥"
+      }
+    },
+    {
+      "id": "21",
+      "achieved_date": "2025-04-30",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "22",
+      "achieved_date": "2025-04-01",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "23",
+      "achieved_date": "2025-04-02",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "24",
+      "achieved_date": "2025-04-03",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "25",
+      "achieved_date": "2025-04-04",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "꽐라냥",
+        "description": "/images/stamp_pic/꽐라냥"
+      }
+    },
+    {
+      "id": "26",
+      "achieved_date": "2025-04-05",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "27",
+      "achieved_date": "2025-04-06",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "28",
+      "achieved_date": "2025-04-07",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "29",
+      "achieved_date": "2025-04-08",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "30",
+      "achieved_date": "2025-04-09",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "독서냥",
+        "description": "/images/stamp_pic/독서냥"
+      }
+    },
+    {
+      "id": "31",
+      "achieved_date": "2025-04-10",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "32",
+      "achieved_date": "2025-04-11",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "33",
+      "achieved_date": "2025-04-12",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "34",
+      "achieved_date": "2025-04-13",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "영화냥",
+        "description": "/images/stamp_pic/영화냥"
+      }
+    },
+    {
+      "id": "35",
+      "achieved_date": "2025-04-14",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    },
+    {
+      "id": "36",
+      "achieved_date": "2025-04-15",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    },
+    {
+      "id": "37",
+      "achieved_date": "2025-04-16",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    },
+    {
+      "id": "38",
+      "achieved_date": "2025-04-17",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    },
+    {
+      "id": "39",
+      "achieved_date": "2025-04-18",
+      "member": {
+        "id": 5,
+        "nickname": "Madara Uchiha",
+        "bio": "소도시의 숨은 매력을 발굴하는 여행 에디터.",
+        "is_public": "TRUE",
+        "status": "ACTIVE",
+        "profile_image": "/images/profile/profile.png"
+      },
+      "stamp": {
+        "id": 1,
+        "name": "맛집냥",
+        "description": "/images/stamp_pic/맛집냥"
+      }
+    }
+  ],
+  "badge": [
+    {
+      "id": "1",
+      "name": "카페인냥",
+      "description": "카페냥 뱃지입니다."
+    },
+    {
+      "id": "2",
+      "name": "산책냥",
+      "description": "산책냥 뱃지입니다."
+    },
+    {
+      "id": "3",
+      "name": "꽐라냥",
+      "description": "꽐라냥 뱃지입니다."
+    },
+    {
+      "id": "4",
+      "name": "독서냥",
+      "description": "독서냥 뱃지입니다."
+    },
+    {
+      "id": "5",
+      "name": "맛집냥",
+      "description": "맛집냥 뱃지입니다."
+    },
+    {
+      "id": "6",
+      "name": "영화냥",
+      "description": "영화냥 뱃지입니다."
+    }
+  ],
+  "member_badge": [
+    {
+      "id": "1",
+      "achived_date": "2025-04-25",
+      "badge_id": 1,
+      "member_id": 5
+    },
+    {
+      "id": "2",
+      "achived_date": "2025-04-25",
+      "badge_id": 2,
+      "member_id": 5
+    },
+    {
+      "id": "3",
+      "achived_date": "2025-04-26",
+      "badge_id": 3,
+      "member_id": 5
+    },
+    {
+      "id": "4",
+      "achived_date": "2025-04-26",
+      "badge_id": 4,
+      "member_id": 5
+    },
+    {
+      "id": "5",
+      "achived_date": "2025-04-27",
+      "badge_id": 5,
+      "member_id": 5
+    }
+  ],
+  "today-diary": [
+    {
+      "id": "1",
+      "date": "2025.04.27",
+      "title": "오늘 신대방동 돈까스 투어",
+      "thumbnail": "/src/assets/thumbnail/donkkaseu.png",
+      "places": [
         {
-          "id": 1,
-          "date": "2025.04.27",
-          "title": "오늘 신대방동 돈까스 투어",
-          "thumbnail": "/src/assets/thumbnail/donkkaseu.png",
-          "places": [
-            { "name": "신대방역 돈까스", "latitude": 37.4921, "longitude": 126.9239 },
-            { "name": "보라매 공원", "latitude": 37.4944, "longitude": 126.9214 },
-            { "name": "이마트 신대방점", "latitude": 37.4928, "longitude": 126.9205 },
-            { "name": "서울대입구 카페거리", "latitude": 37.4784, "longitude": 126.9527 }
-          ]
+          "name": "신대방역 돈까스",
+          "latitude": 37.4921,
+          "longitude": 126.9239
+        },
+        {
+          "name": "보라매 공원",
+          "latitude": 37.4944,
+          "longitude": 126.9214
+        },
+        {
+          "name": "이마트 신대방점",
+          "latitude": 37.4928,
+          "longitude": 126.9205
+        },
+        {
+          "name": "서울대입구 카페거리",
+          "latitude": 37.4784,
+          "longitude": 126.9527
         }
       ]
+    }
+  ],
+  "reports": [
+    {
+      "id": "1",
+      "created_at": "2025.03.13",
+      "report_type": "게시글",
+      "reported_id": 1,
+      "content": "이 게시글은 부적절한 내용을 포함하고 있습니다.",
+      "status": "처리중",
+      "member_id": 3,
+      "report_reason_id": "5"
+    },
+    {
+      "id": "2",
+      "created_at": "2025.03.13",
+      "report_type": "댓글",
+      "reported_id": 5,
+      "content": "댓글에 욕설이 포함되어 있습니다.",
+      "status": "반려",
+      "member_id": 4,
+      "report_reason_id": "2"
+    },
+    {
+      "id": "3",
+      "created_at": "2025.03.18",
+      "report_type": "게시글",
+      "reported_id": 12,
+      "content": "스팸성 홍보 글입니다.",
+      "status": "반려",
+      "member_id": 10,
+      "report_reason_id": 1
+    },
+    {
+      "id": "4",
+      "created_at": "2025.04.02",
+      "report_type": "게시글",
+      "reported_id": 42,
+      "content": "불건전한 내용을 담고 있는 게시글입니다.",
+      "status": "처리중",
+      "member_id": 22,
+      "report_reason_id": 5
+    },
+    {
+      "id": "5",
+      "created_at": "2025.04.15",
+      "report_type": "회원",
+      "reported_id": 7,
+      "content": "부적절한 회원 활동 신고입니다.",
+      "status": "처리중",
+      "member_id": 14,
+      "report_reason_id": 9
+    }
+  ],
+  "report_reasons": [
+    {
+      "id": "1",
+      "reason": "스팸/홍보성 콘텐츠"
+    },
+    {
+      "id": "2",
+      "reason": "음란물/선정적 콘텐츠"
+    },
+    {
+      "id": "3",
+      "reason": "욕설/비하/혐오 표현"
+    },
+    {
+      "id": "4",
+      "reason": "개인정보 노출"
+    },
+    {
+      "id": "5",
+      "reason": "불법 정보 공유 (저작권 침해 등)"
+    },
+    {
+      "id": "6",
+      "reason": "사기/허위 사실 유포"
+    },
+    {
+      "id": "7",
+      "reason": "자해/자살 유도"
+    },
+    {
+      "id": "8",
+      "reason": "폭력/위협적 내용"
+    },
+    {
+      "id": "9",
+      "reason": "부적절한 프로필/닉네임"
+    },
+    {
+      "id": "10",
+      "reason": "기타 (직접 입력)"
+    }
+  ]
 }

--- a/my-local-diary/src/router/index.js
+++ b/my-local-diary/src/router/index.js
@@ -8,9 +8,10 @@ import PostCreate from '@/components/post/PostCreate.vue'
 import TestMarker from '@/views/TestMarker.vue';
 import EditProfile from '@/components/mypage/EditProfile.vue'
 import EditAccount from '@/components/mypage/EditAccount.vue';
-
+import ReportManagement from '@/views/ReportManagement.vue'; 
 import TempLoadingModalParent from '@/components/common/TempLoadingModalParent.vue';
 import EditPage from '@/views/mypage/EditPage.vue';
+
 
 const routes = [
     {
@@ -83,7 +84,12 @@ const routes = [
         path: '/loadingmodal',
         name: 'LoadingModal',
         component: TempLoadingModalParent
-      }
+      },
+      {
+        path: '/admin/reports',
+        name: 'ReportManagement',
+        component: ReportManagement
+    }
 ]
 
 const router = createRouter({

--- a/my-local-diary/src/views/ReportManagement.vue
+++ b/my-local-diary/src/views/ReportManagement.vue
@@ -1,0 +1,248 @@
+<template>
+    <div class="report-management">
+      <!-- 고양이 그림 + 제목 -->
+      <div class="header">
+        <img src="/src/assets/stamp_pic/cat_bar.png" alt="고양이" class="cat-image" />
+        <div class="title">신고 관리</div>
+      </div>
+  
+      <!-- 테이블 -->
+      <table class="report-table" v-if="reports.length">
+        <thead>
+          <tr>
+            <th>신고 번호</th>
+            <th>신고 신청일</th>
+            <th>신고 대상 유형</th>
+            <th>신고 대상 번호</th>
+            <th>신고내용</th>
+            <th>처리 상태</th>
+            <th>신고자 id</th>
+            <th>신고 사유 번호</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="report in reports" :key="report.id">
+            <td>{{ report.id }}</td>
+            <td>{{ report.created_at }}</td>
+            <td>{{ report.report_type }}</td>
+            <td>{{ report.reported_id }}</td>
+            <td>
+              <button class="detail-button" @click="openModal(report.content)">자세히보기</button>
+            </td>
+            <td>
+              <select v-model="report.status" @change="updateReportStatus(report)">
+                <option value="처리중">처리중</option>
+                <option value="처리완료">처리완료</option>
+                <option value="반려">반려</option>
+              </select>
+            </td>
+            <td>{{ report.member_id }}</td>
+            <td>
+              <div class="reason-select">
+                <select v-model="report.report_reason_id" @change="handleReasonChange(report)">
+                  <option v-for="reason in reportReasons" :key="reason.id" :value="reason.id">
+                    {{ reason.reason }}
+                  </option>
+                </select>
+                <div v-if="report.report_reason_id === 10">
+                  <input
+                    v-model="report.custom_reason"
+                    type="text"
+                    placeholder="신고 사유를 입력하세요"
+                    class="custom-reason-input"
+                  />
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+  
+      <div v-else>로딩중...</div>
+  
+      <!-- 신고 내용 모달 -->
+      <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
+        <div class="modal">
+          <h3>신고 내용</h3>
+          <p>{{ selectedContent }}</p>
+          <button @click="closeModal" class="close-button">닫기</button>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  import axios from 'axios';
+  
+  export default {
+    data() {
+      return {
+        reports: [],
+        reportReasons: [],
+        showModal: false,
+        selectedContent: '',
+      };
+    },
+    created() {
+      this.fetchReports();
+      this.fetchReportReasons();
+    },
+    methods: {
+      async fetchReports() {
+        try {
+          const response = await axios.get('http://localhost:3001/reports');
+          this.reports = response.data.map(report => ({
+            ...report,
+            custom_reason: '',
+          }));
+        } catch (error) {
+          console.error('Failed to fetch reports', error);
+        }
+      },
+      async fetchReportReasons() {
+        try {
+          const response = await axios.get('http://localhost:3001/report_reasons');
+          this.reportReasons = response.data;
+        } catch (error) {
+          console.error('Failed to fetch report reasons', error);
+        }
+      },
+      openModal(content) {
+        this.selectedContent = content;
+        this.showModal = true;
+      },
+      closeModal() {
+        this.showModal = false;
+        this.selectedContent = '';
+      },
+      async updateReportStatus(report) {
+        try {
+          await axios.patch(`http://localhost:3001/reports/${report.id}`, {
+            status: report.status,
+          });
+          // 업데이트 성공해도 alert 띄우지 않음
+        } catch (error) {
+          console.error('Failed to update report status', error);
+        }
+      },
+      async handleReasonChange(report) {
+        if (report.report_reason_id !== 10) {
+          report.custom_reason = '';
+          await this.updateReportReason(report);
+        }
+      },
+      async updateReportReason(report) {
+        try {
+          await axios.patch(`http://localhost:3001/reports/${report.id}`, {
+            report_reason_id: report.report_reason_id,
+          });
+          // 업데이트 성공해도 alert 띄우지 않음
+        } catch (error) {
+          console.error('Failed to update report reason', error);
+        }
+      }
+    },
+  };
+  </script>
+  
+  <style scoped>
+  .report-management {
+    padding: 20px;
+    padding-left: 220px; /* 사이드바 공간 확보 */
+  }
+  
+  .header {
+    position: relative;
+    width: 300px;
+    margin-bottom: 20px;
+  }
+  
+  .cat-image {
+    width: 100%;
+  }
+  
+  .title {
+    position: absolute;
+    top:50px;
+    left: 20px;
+    font-size: 24px;
+    font-weight: bold;
+    color: black;
+  }
+  
+  .report-table {
+    width: 100%;
+    min-width: 1000px; /* 테이블 넓이 확보 */
+    border-collapse: collapse;
+  }
+  
+  .report-table th,
+  .report-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: center;
+  }
+  
+  .detail-button {
+    background-color: transparent;
+    border: 1px solid #ccc;
+    padding: 5px 10px;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  
+  select {
+    padding: 6px 30px 6px 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: url('data:image/svg+xml;charset=US-ASCII,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="5" viewBox="0 0 10 5"><path fill="none" stroke="%23333" stroke-width="1" d="M0 0l5 5 5-5"/></svg>') no-repeat right 10px center;
+    background-size: 10px 5px;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
+  
+  .reason-select {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .custom-reason-input {
+    margin-top: 5px;
+    padding: 5px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  
+  /* 모달 스타일 */
+  .modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .modal {
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    min-width: 300px;
+    text-align: center;
+  }
+  
+  .close-button {
+    margin-top: 20px;
+    padding: 5px 10px;
+    background: #ccc;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  </style>
+  


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
 관리자 페이지 추가

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
feat/report

## 📂 관련 이슈 (Issue)
close #41 

## 💡 추가 설명 (Additional Info)
신고관리는 아무래도 관리자만 쓰는 페이지다 보니 그냥 단순하고 깔끔한 ui로 설계했습니다.
/admin/reports로 가시면 됩니다.
제가 신고사유는 대충 10개 정해서 db.json에 넣어놨고 해당 내용도 혹시나 erd cloud에 추가했습니다,
이 규정이 괜찮아보이시면 그대로 사용하시면 됩니다.

## 📎 기타 참고 사항
**근데 이걸 관리자가 로그인했을 때 어느 버튼을 눌러야 가게 할지...? 
admin계정의 경우 일반 회원과 달리 뜨는 페이지가 달라야 하는데 어떻게 다르게 할지?.. 흠.. 따로 정한 건 없는 것 같아서 
일단 이 부분은 백엔드까지 다 하고.. 고려할까요?,,**

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ff2a5d11-1d25-442a-8c6a-2fb3f3c4a079)
