### PR TITLE
[FEAT] 다른 유저 페이지 이동 시 상태 처리

### DIFF
--- a/my-local-diary/public/json/db.json
+++ b/my-local-diary/public/json/db.json
@@ -524,6 +524,12 @@
       "following_member_id": "5",
       "follower_target_member_id": "8",
       "status": "wait"
+    },
+    {
+      "id": "5a03",
+      "following_member_id": 2,
+      "follower_target_member_id": "5",
+      "status": "wait"
     }
   ],
   "member_stamp": [

--- a/my-local-diary/src/components/common/Sidebar.vue
+++ b/my-local-diary/src/components/common/Sidebar.vue
@@ -17,15 +17,22 @@
               v-if="!ui.isHover"
               src="/src/assets/cursor/슈크림붕어빵1.png"
               width="40"
+              height="40"
+              aspect-ratio="1"
             />
             <transition name="fade">
-              <v-img
-                v-if="ui.showImage"
-                src="/src/assets/logo/My_Local_Diary.png"
-              />
+              <div v-if="ui.showImage">
+                <v-img
+                  src="/src/assets/logo/My_Local_Diary.png"
+                  width="120"
+                  height="40"
+                  aspect-ratio="3"
+                />
+              </div>
             </transition>
           </div>
         </v-list-item>
+
 
         <!-- ✨ 메뉴 항목 -->
         <template v-if="!isAdmin">
@@ -162,7 +169,7 @@ const isAdmin = ref(userStore.isAdmin)  // 관리자 테스트용
 
 
 onMounted(async () => {
-  // await userStore.restoreUser()
+  await userStore.restoreUser()
   isAdmin.value = userStore.role === 'ADMIN'
   fetchNotifications()
 })
@@ -190,7 +197,7 @@ const unreadCount = computed(() =>
 
 const fetchNotifications = async () => {
   try {
-    const token = localStorage.getItem('accessToken')
+    const token = userStore.token;
     const res = await axios.get('http://localhost:8080/api/notifications', {
       headers: { Authorization: `Bearer ${token}` }
     })
@@ -234,12 +241,6 @@ const reportProblem = () => console.log('문제 신고 창 열기')
 
 // 로그아웃
 async function confirmLogout() {
-  // if (!accessToken) {
-  //   console.warn('⚠️ 토큰 없음 → 바로 로그아웃');
-  //   userStore.logout();
-  //   router.push('/');
-  //   return;
-  // }
   console.log('logout accessToken:', userStore.token);
   try {
     await axios.post('http://localhost:8080/api/member/logout', null, {

--- a/my-local-diary/src/components/common/userprofile.vue
+++ b/my-local-diary/src/components/common/userprofile.vue
@@ -90,7 +90,7 @@ const musicTitle = computed(() => {
 })
 
 // 본인 프로필인지 여부
-const isMyProfile = props.isMine
+const isMyProfile = computed(() => props.isMine)
 
 // LDRS 로딩 이펙트 등록
 waveform.register()
@@ -145,6 +145,7 @@ watch(() => props.userData.profileMusic, (newVal) => {
       })
   }
 })
+
 
 // 프로필 수정 이동
 const editProfile = () => router.push('/edit/profile')

--- a/my-local-diary/src/components/common/userprofile.vue
+++ b/my-local-diary/src/components/common/userprofile.vue
@@ -98,10 +98,8 @@ const handleFollow = async () => {
 
 
 const props = defineProps({
-  userData: {
-    type: Object,
-    required: true
-  }
+  userData: Object,
+  isMine: Boolean
 })
 
 const route = useRoute()
@@ -111,7 +109,8 @@ console.log(currentParam)
 const router = useRouter();
 const userStore = useUserStore()
 
-const isMyProfile = computed(() =>  Number(currentParam) === userStore.id)
+// const isMyProfile = computed(() =>  Number(currentParam) === userStore.id)
+const isMyProfile = props.isMine;
 
 const audioPlayer = ref(null)
 const isPlaying = ref(false)

--- a/my-local-diary/src/main.js
+++ b/my-local-diary/src/main.js
@@ -8,15 +8,6 @@ import 'swiper/css/pagination';
 
 import '@mdi/font/css/materialdesignicons.css'  // 아이콘
 
-// main.js 또는 App.vue의 setup이나 onMounted 등에서
-
-// const TEMP_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QGVtYWlsLmNvbSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzQ1OTA2MTM1LCJleHAiOjE3NDU5NDkzMzV9.1UOC3RseaAZ-QKxbEsKAVlWFBCNA18jR6SOnGfVq38iDWOOKOl1xC4Jm5HVGRfVpR5gskTr3sf9wtY27Bas1uQ';
-
-// if (!localStorage.getItem('accessToken')) {
-//   localStorage.setItem('accessToken', TEMP_TOKEN);
-// }
-
-
 // ⭐ Naver Maps API 스크립트 동적 로딩
 const loadNaverMapsScript = () => {
   return new Promise((resolve, reject) => {

--- a/my-local-diary/src/stores/userStore.js
+++ b/my-local-diary/src/stores/userStore.js
@@ -69,6 +69,7 @@ export const useUserStore = defineStore('user', () => {
       await fetchProfileStats();
 
       localStorage.setItem('user', JSON.stringify({
+        token: token.value,   // 액세스 토큰
         id: id.value,
         loginId: loginId.value,
         name: name.value,
@@ -147,7 +148,8 @@ export const useUserStore = defineStore('user', () => {
     
     if (savedUser) {
       const user = JSON.parse(savedUser);
-  
+      
+      token.value = user.token;
       id.value = user.id;
       loginId.value = user.loginId;
       name.value = user.name;

--- a/my-local-diary/src/views/mypage/Mypage.vue
+++ b/my-local-diary/src/views/mypage/Mypage.vue
@@ -6,7 +6,11 @@
           class="left-side"
           style="flex: 6; border-right: 1px solid #E5E7EB; box-shadow: 4px 0 12px -4px rgba(0, 0, 0, 0.1); flex-direction: column;"
         >
-          <UserProfile :userData="userStore" />
+          <UserProfile
+            v-if="profileUserData"
+            :userData="profileUserData"
+            :isMyProfile="isMyProfile"
+          />
 
           <div class="mini-map">
             <router-link to="/user-map-home" class="mini-map-link">지도에서 보기 →</router-link>
@@ -35,27 +39,74 @@
 
 
 <script setup>
-  import { onMounted, ref } from 'vue';
+  import { onMounted, ref, computed , watch } from 'vue';
+  import { useRoute } from 'vue-router'
+  import { useUserStore } from '@/stores/userStore.js';
+  import axios from 'axios'
+
   import MiniMap from '@/components/mypage/MiniMap.vue';
   import UserProfile from '@/components/common/userprofile.vue';
-  import { useUserStore } from '@/stores/userStore.js';
   import TodayDiary from '@/components/mypage/TodayDiary.vue';
   import Temp from '@/components/mypage/Temp.vue';
-  import { useRoute } from 'vue-router'
-
-  const route = useRoute()
-  const currentPage = route.params.id;
-  console.log(currentPage)
-
-  
 
   const userStore = useUserStore();
+  const route = useRoute()
+
+  const profileUserData = ref(null);   // 다른 사람 또는 내 정보
+  const routeUserId = computed(() => Number(route.params.id));
+  const isMine = computed(() => routeUserId.value === userStore.id);
+
+
+  // 다른 유저일 경우 백엔드에서 fetch
+  const fetchUserProfile = async () => {
+    if (isMine.value) {
+      console.log("로그인한 유저의 정보 가져오기")
+
+      profileUserData.value = {
+        id: userStore.id,
+        loginId: userStore.loginId,
+        nickname: userStore.nickname,
+        email: userStore.email,
+        birth: userStore.birth,
+        role: userStore.role,
+        status: userStore.status,
+        isPublic: userStore.isPublic,
+        bio: userStore.bio,
+        profileImage: userStore.profileImage,
+        profileMusic: userStore.profileMusic,
+        followers: userStore.followers,
+        following: userStore.following,
+        posts: userStore.posts
+      };
+    } else {
+     console.log('다른 유의의 정보 가져오기')
+      console.log(userStore.token)
+      try {
+        console.log("🔍 요청 대상 ID:", routeUserId.value);
+        console.log("🔍 현재 로그인한 내 ID:", userStore.id)
+        console.log("🟡 isMine:", isMine.value)
+        const res = await axios.get(`http://localhost:8080/api/member/${routeUserId.value}`, {
+          headers: {
+            Authorization: `Bearer ${userStore.token}`
+          }
+        });
+        console.log(res.data)
+        profileUserData.value = res.data.data;
+      } catch (err) {
+        console.error('❌ 유저 정보 조회 실패:', err);
+      }
+    }
+  };
 
 
   onMounted(async () => {
-    await userStore.restoreUser();
+    await userStore.restoreUser(); // Pinia 상태 복구
+    console.log(userStore.token)
+    await fetchUserProfile(); // 데이터 로딩
   });
 
+  // 라우터가 바뀌는 경우에도 유저 다시 가져오기
+  watch(() => route.params.id, fetchUserProfile);
 </script>
 
 <style scoped>

--- a/my-local-diary/src/views/mypage/Mypage.vue
+++ b/my-local-diary/src/views/mypage/Mypage.vue
@@ -9,7 +9,7 @@
           <UserProfile
             v-if="profileUserData"
             :userData="profileUserData"
-            :isMyProfile="isMyProfile"
+            :isMine="isMine"
           />
 
           <div class="mini-map">


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 로그인 , 로그아웃 처리 추가 수정
- 로그인 유저의 마이페이지, 다른 유저의 마이페이지 상태 처리

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- feature/map

## 📂 관련 이슈 (Issue)
- close #

## 💡 추가 설명 (Additional Info)


## 📎 기타 참고 사항
- 다른 유저의 팔로잉 , 팔로워, 게시글 정보는 아직 백엔드 조회 기능이 구현되어 있지 않아 미구현된 상태입니다. 
- url에 직접 id 변경해서 들어가는 방식으로 확인 가능합니다.




## 📸 스크린샷 (선택)
- 로그인 유저 마이페이지 (로그인 유저 id =1)
![image](https://github.com/user-attachments/assets/0df99245-ecbd-4026-8365-c35d4076cc61)

- 다른 유저의 마이 페이지 이동 시, (다른 유저 id =2)
![image](https://github.com/user-attachments/assets/0af01d07-1445-419e-aeae-93b930b2b991)


