### PR TITLE
[대기] 팔로우알림 실시간성 더 확보, 비공개계정의 수락/거절 추가

### DIFF
--- a/my-local-diary/src/components/common/NotificationPopup.vue
+++ b/my-local-diary/src/components/common/NotificationPopup.vue
@@ -53,7 +53,7 @@ const props = defineProps({ isOpen: Boolean })
 const emit = defineEmits(['close'])
 const router = useRouter()
 const notificationStore = useNotificationStore()
-const userStore = useUserStore()
+const userStore = useUserStore();
 
 
 const handleNotificationClick = async (id, targetId) => {


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
프론트에서변경사항 많이 생겼는데 이게 pr이 안먹어서.. 이것 저것 하다보니 **이 pr에서 file changed에 변경사항 별로 없어보이지만
sidebar랑  notificationpopup searchmodal 이쪽부분 정말 많이바뀌었어요**

그래서 꼭 테스트...부탁드려요(제 최신 백엔드 pr로, db정리하고 공개계정 민수, 비공개계정 혜영으로 하면됩니다.)

그리고 원래 실시간성이 좀 애매해서 이전 pr까지는 사이드바에 알람눌러야 알람이 개수가 업데이트되었는데
**다른유저가 팔로우 요청보내면 가만히 있어도 사이드바에 5초 안에 자동으로 알림개수가 뜹니다.** 

읽으면(알람을 클릭하면) 알림개수 감소합니다. 
수락/거절눌러도 마찬가지>> 이경우에는 아예 알림자체를 db에서 사라지게 함; 
공개계정의 경우에만 수락/거절 안눌러도 되므로 알림db에 남아있어요. 그래서 이건 알림창에 여전히 존재합니다.

현재는 사이드바의 서치 모달에서 유저를 찾아서 팔로우 요청 보내는 것 밖에 안되지만
민선님이 타유저페이지만드시면 거기서도  프로필에 있는 팔로우 버튼 눌러서 요청, 알림뜨게하는것도 추가할 예정입니다.




## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)

feature/notification

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)

## 💡 추가 설명 (Additional Info)


## 📎 기타 참고 사항


## 📸 스크린샷 (선택)
![알람실시간성더추가](https://github.com/user-attachments/assets/e860cbff-903b-42d4-887e-02d9da5b1ee3)

![수락거절시 자동으로 알림삭제 처리, 팔로우로직도처리됨](https://github.com/user-attachments/assets/e48eb877-1cf1-4cf7-9c25-b83523c06a11)

비공개 계정의 수락/거절의 경우 바로 알림창에서 삭제되고 알림db에서도 삭제되지만
팔로우로직은 팔로우db도 처리되므로 걱정하지마세요
