### PR TITLE
[FEAT] 회원 로그인, 로그아웃, 토큰 재발급 연동 완료

### DIFF
--- a/my-local-diary/package-lock.json
+++ b/my-local-diary/package-lock.json
@@ -13,6 +13,7 @@
         "chart.js": "^4.4.9",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
+        "jwt-decode": "^4.0.0",
         "ldrs": "^1.1.7",
         "lucide-vue-next": "^0.503.0",
         "pinia": "^3.0.2",
@@ -2813,6 +2814,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kolorist": {

--- a/my-local-diary/package.json
+++ b/my-local-diary/package.json
@@ -14,6 +14,7 @@
     "chart.js": "^4.4.9",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "jwt-decode": "^4.0.0",
     "ldrs": "^1.1.7",
     "lucide-vue-next": "^0.503.0",
     "pinia": "^3.0.2",

--- a/my-local-diary/src/components/common/Sidebar.vue
+++ b/my-local-diary/src/components/common/Sidebar.vue
@@ -233,20 +233,23 @@ const reportProblem = () => console.log('문제 신고 창 열기')
 
 // 로그아웃
 async function confirmLogout() {
-  console.log('logout accessToken:', userStore.token);
-  try {
-    await axios.post('http://localhost:8080/api/member/logout', null, {
-      headers: {
-        Authorization: `Bearer ${userStore.token}`
-      }
-    })
+  // console.log('logout accessToken:', userStore.token);
+  // try {
+  //   await axios.post('http://localhost:8080/api/member/logout', null, {
+  //     headers: {
+  //       Authorization: `Bearer ${userStore.token}`
+  //     }
+  //   })
 
-    userStore.logout()
-    router.push('/')
-  } catch (err) {
-    console.error('❌ 로그아웃 실패', err)
-  }
+  //   userStore.logout()
+  //   router.push('/')
+  // } catch (err) {
+  //   console.error('❌ 로그아웃 실패', err)
+  // }
+  await userStore.logout();
+  router.push('/')
 }
+
 
 const goToRegulationHistory = () => router.push('/admin/regulations')
 const goToReportHistory = () => router.push('/admin/reports')

--- a/my-local-diary/src/main.js
+++ b/my-local-diary/src/main.js
@@ -8,6 +8,7 @@ import 'swiper/css/pagination';
 
 import '@mdi/font/css/materialdesignicons.css'  // 아이콘
 
+
 // ⭐ Naver Maps API 스크립트 동적 로딩
 const loadNaverMapsScript = () => {
   return new Promise((resolve, reject) => {
@@ -27,12 +28,12 @@ const loadNaverMapsScript = () => {
 };
 
 loadNaverMapsScript()
-  .then(() => {
+  .then(async () => {
     console.log('✅ Naver Maps script loaded!')
-    
+
     const pinia = createPinia()
     const app = createApp(App)
-    
+
     app.use(router)
     app.use(vuetify)
     app.use(pinia)
@@ -45,4 +46,3 @@ loadNaverMapsScript()
 
 
 
-  

--- a/my-local-diary/src/router/index.js
+++ b/my-local-diary/src/router/index.js
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Mypage from '@/views/mypage/Mypage.vue'
 import Landingpage from '@/views/Landingpage.vue';
-import MapHome from '@/views/MapHome.vue'; 
+import MapHome from '@/views/MapHome.vue';
 import StampPage from '@/views/Stamppage.vue';
 import UserMapView from '@/views/UserMapView.vue';
 import PostCreate from '@/components/post/PostCreate.vue'
@@ -14,105 +14,104 @@ import ReportManagement from '@/views/admin/ReportManagement.vue';
 import RegulationHistory from '@/views/admin/RegulationHistory.vue';
 import AdminMyPage from '@/views/admin/AdminMyPage.vue';
 
-
 const routes = [
-    {
-        path: '/',
-        name: 'Landing',
-        // beforeEnter: (to, from, next) => {
-        //   if (isLoggedIn()) {
-        //     next('/dashboard'); // 로그인한 유저는 대시보드로
-        //   } else {
-        //     next(); // 로그인 안 한 유저는 랜딩 페이지
-        //   }
-        // },
-        component: Landingpage, // 처음 화면을 랜딩페이지로 보이게 하려면 이거!
-      },
-      {
-        path: '/mypage',
-        name: 'Mypage',
-        component: Mypage,
-      },
-      {
-        path: '/map-home',
-        name: 'MapHome',
-        component : MapHome
-      },
-      {
-        path: '/home',
-        name: 'MapHome',
-        component : MapHome
-      },
-      {
-        path: '/marker',
-        name: 'TestMarker',
-        component : TestMarker
-      },
-      {
-        path: '/mypage/:id',      
-        name: 'Mypage',
-        component: Mypage,
-        props: true
-      },
-      
-      {
-        path: '/edit',
-        component: EditPage,  // EditPage 내부에서 분기
-        children: [
-          {
-            path: 'profile',
-            component: EditProfile
-          },
-          {
-            path: 'account',
-            component: EditAccount
-          }
-        ]
-      },
-      {
-        path: '/stamp/:id',      
-        name: 'Stamp',
-        component: StampPage,
-        props: true
-      },
-      {
-        path: '/user-map-home',
-        name: 'UserMapHome',
-        component: UserMapView,
-      },
-      {
-        path: '/post/create',
-        name: 'PostCreate',
-        component: PostCreate
-      },
-      {
-        path: '/loadingmodal',
-        name: 'LoadingModal',
-        component: TempLoadingModalParent
-      },
+  {
+    path: '/',
+    name: 'Landing',
+    // beforeEnter: (to, from, next) => {
+    //   if (isLoggedIn()) {
+    //     next('/dashboard'); // 로그인한 유저는 대시보드로
+    //   } else {
+    //     next(); // 로그인 안 한 유저는 랜딩 페이지
+    //   }
+    // },
+    component: Landingpage, // 처음 화면을 랜딩페이지로 보이게 하려면 이거!
+  },
+  {
+    path: '/mypage',
+    name: 'Mypage',
+    component: Mypage,
+  },
+  {
+    path: '/map-home',
+    name: 'MapHome',
+    component: MapHome
+  },
+  {
+    path: '/home',
+    name: 'MapHome',
+    component: MapHome
+  },
+  {
+    path: '/marker',
+    name: 'TestMarker',
+    component: TestMarker
+  },
+  {
+    path: '/mypage/:id',
+    name: 'Mypage',
+    component: Mypage,
+    props: true
+  },
 
-      // 관리자용 
+  {
+    path: '/edit',
+    component: EditPage,  // EditPage 내부에서 분기
+    children: [
       {
-        path: '/admin/reports',
-        name: 'ReportManagement',
-        component: ReportManagement
-    },
-    {
-      path: '/profile/:id',
-      name: 'Profile',
-      component: Mypage // 🔥 임시로(팔로우기능중...)
-    },
-    
-      {
-        path: '/admin/regulations',
-        name: 'RegulationHistory',
-        component: RegulationHistory
+        path: 'profile',
+        component: EditProfile
       },
       {
-        path: '/admin/mypage',
-        name: 'AdminMyPage',
-        component: AdminMyPage
-      },
+        path: 'account',
+        component: EditAccount
+      }
+    ]
+  },
+  {
+    path: '/stamp/:id',
+    name: 'Stamp',
+    component: StampPage,
+    props: true
+  },
+  {
+    path: '/user-map-home',
+    name: 'UserMapHome',
+    component: UserMapView,
+  },
+  {
+    path: '/post/create',
+    name: 'PostCreate',
+    component: PostCreate
+  },
+  {
+    path: '/loadingmodal',
+    name: 'LoadingModal',
+    component: TempLoadingModalParent
+  },
+
+  // 관리자용 
+  {
+    path: '/admin/reports',
+    name: 'ReportManagement',
+    component: ReportManagement
+  },
+  {
+    path: '/profile/:id',
+    name: 'Profile',
+    component: Mypage // 🔥 임시로(팔로우기능중...)
+  },
+
+  {
+    path: '/admin/regulations',
+    name: 'RegulationHistory',
+    component: RegulationHistory
+  },
+  {
+    path: '/admin/mypage',
+    name: 'AdminMyPage',
+    component: AdminMyPage
+  },
 ]
 
 const router = createRouter({

--- a/my-local-diary/src/stores/userStore.js
+++ b/my-local-diary/src/stores/userStore.js
@@ -2,6 +2,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import axios from 'axios';
+import { jwtDecode } from 'jwt-decode'
 
 export const useUserStore = defineStore('user', () => {
   // ✅ state
@@ -22,18 +23,20 @@ export const useUserStore = defineStore('user', () => {
   const following = ref(0)
   const posts = ref(0)
 
+  // 강제 로그아웃(토큰 만료)
+  const forcedLogout = ref(false)
+
   const isLoggedIn = computed(() => !!id.value)
 
   const welcomeMessage = computed(() => {
     return nickname.value ? `안녕하세요, ${nickname.value}님!` : ''
   })
 
-  async function login(accessToken, refreshToken) {
+  async function login(accessToken) {
     console.log('로그인하러 넘어 옴')
 
-
-    // 1. 액세스 토큰, 리프레시 토큰 저장
-    localStorage.setItem('refreshToken', refreshToken);
+    // 1. 액세스 토큰, 리프레시 토큰 저장 -> 리프레시 토큰은 이제 http-only 쿠키로 관리
+    // localStorage.setItem('refreshToken', refreshToken);
     token.value = accessToken;
     console.log(token.value)
 
@@ -42,7 +45,7 @@ export const useUserStore = defineStore('user', () => {
       console.log('사용자 정보 요청');
       const response = await axios.get('http://localhost:8080/api/member/info', {
         headers: {
-          Authorization: `Bearer ${accessToken}`
+          Authorization: `Bearer ${token.value}`
         }
       });
 
@@ -69,7 +72,7 @@ export const useUserStore = defineStore('user', () => {
       await fetchProfileStats();
 
       localStorage.setItem('user', JSON.stringify({
-        token: token.value,   // 액세스 토큰
+        // token: token.value,   // 액세스 토큰
         id: id.value,
         loginId: loginId.value,
         name: name.value,
@@ -94,8 +97,31 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  function logout() {
-    // 1. 상태 초기화
+  // ✅ 서버 로그아웃 + 상태 초기화
+  async function logout() {
+    try {
+      if (token.value) {
+        await axios.post('http://localhost:8080/api/member/logout', null, {
+          headers: { Authorization: `Bearer ${token.value}` },
+          withCredentials: true,
+        })
+      }
+    } catch (error) {
+      console.warn("❌ 로그아웃 요청 실패, 무시하고 상태 초기화 진행")
+    }
+
+    // 상태 초기화
+    clearState()
+  }
+
+  // ✅ 강제 로그아웃 처리
+  function forceLogout() {
+    forcedLogout.value = true
+    clearState()
+  }
+
+  function clearState() {
+    token.value = null
     id.value = null
     loginId.value = ''
     name.value = ''
@@ -111,13 +137,9 @@ export const useUserStore = defineStore('user', () => {
     followers.value = 0
     following.value = 0
     posts.value = 0
-  
-    // 2. localStorage 정리
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('user');
-    localStorage.removeItem('access_token'); // ✅ 이거 꼭!
+    localStorage.removeItem('user')
+    localStorage.removeItem('refreshToken')
   }
-  
 
   async function fetchProfileStats() {
     if (!id.value) {
@@ -146,29 +168,78 @@ export const useUserStore = defineStore('user', () => {
   }
   async function restoreUser() {
     const savedUser = localStorage.getItem('user');
-    
-    if (savedUser) {
-      const user = JSON.parse(savedUser);
-      
-      token.value = user.token;
-      id.value = user.id;
-      loginId.value = user.loginId;
-      name.value = user.name;
-      nickname.value = user.nickname;
-      email.value = user.email;
-      birth.value = user.birth;
-      role.value = user.role;
-      status.value = user.status;
-      isPublic.value = user.isPublic;
-      bio.value = user.bio;
-      profileImage.value = user.profileImage;
-      profileMusic.value = user.profileMusic;
-  
-      await fetchProfileStats();
-    }
 
+    if (savedUser) {
+
+      try {
+        const res = await axios.post('http://localhost:8080/api/member/reissue', null, {
+          withCredentials: true
+        });
+
+        const newAcessToken = res.data.data.accessToken;
+        console.log(newAcessToken);
+        token.value = newAcessToken;
+        const user = JSON.parse(savedUser);
+
+        id.value = user.id;
+        loginId.value = user.loginId;
+        name.value = user.name;
+        nickname.value = user.nickname;
+        email.value = user.email;
+        birth.value = user.birth;
+        role.value = user.role;
+        status.value = user.status;
+        isPublic.value = user.isPublic;
+        bio.value = user.bio;
+        profileImage.value = user.profileImage;
+        profileMusic.value = user.profileMusic;
+
+        await fetchProfileStats();
+      } catch (err) {
+        if (err.response && err.response.status == 401) {
+          const msg = err.response.data.message;
+          alert(msg);
+        }
+        logout();
+      }
+
+    }
   }
-  
+
+  async function tryReissueToken() {
+    try {
+      const res = await axios.post('http://localhost:8080/api/member/reissue', null, {
+        withCredentials: true // ✅ refresh-token은 httpOnly 쿠키
+      })
+      const newAccessToken = res.data.data.accessToken
+      token.value = newAccessToken
+
+      const saved = JSON.parse(localStorage.getItem('user') || '{}')
+      saved.token = newAccessToken
+      localStorage.setItem('user', JSON.stringify(saved))
+    } catch (err) {
+      console.error("⛔ 재발급 실패. 로그아웃 처리")
+      forcedLogout.value = true
+      logout()
+      router.push('/')
+    }
+  }
+
+  // 🔁 30초마다 access token 만료 확인
+  setInterval(() => {
+    if (!token.value) return
+    try {
+      const decoded = jwtDecode(token.value)
+      const now = Math.floor(Date.now() / 1000)
+      const exp = decoded.exp
+      const remaining = exp - now
+      if (remaining <= 60) {
+        tryReissueToken()
+      }
+    } catch (e) {
+      console.error("⛔ JWT 디코드 실패", e)
+    }
+  }, 30000)
 
   return {
     id,
@@ -192,6 +263,8 @@ export const useUserStore = defineStore('user', () => {
     login,
     logout,
     fetchProfileStats,
-    restoreUser
+    restoreUser,
+    tryReissueToken,
+    forceLogout
   }
 })

--- a/my-local-diary/src/views/Landingpage.vue
+++ b/my-local-diary/src/views/Landingpage.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-container fluid class="fill-height d-flex align-center justify-center pa-4" style="background-color: black; color: white;">
+    <v-container v-if = "!isRestoring" fluid class="fill-height d-flex align-center justify-center pa-4" style="background-color: black; color: white;">
       <v-row class="ma-0" align="center" justify="center">
         <v-col cols="12" md="10" lg="8">
           <v-card class="d-flex flex-row pa-0" elevation="6" style="background-color: transparent;">
@@ -89,20 +89,14 @@
 
   const inputId = ref("");
   const inputPw = ref("");
-
-  // 
+  const isRestoring = ref(false);
+  
   onMounted(async () => {
-    const token = localStorage.getItem('accessToken');
-    
-    if (token) {
-      try {
-        await userStore.login(token);
-        router.push('/home');
-      } catch (err) {
-        console.warn("⛔ 유효하지 않은 토큰, 자동 로그인 실패");
-        userStore.logout();
-        router.push('/');
-      }
+    // const token = localStorage.getItem('accessToken');
+    await userStore.restoreUser();
+    isRestoring.value = true;
+    if (userStore.isLoggedIn) {
+      router.push('/home');
     }
   });
 
@@ -122,17 +116,18 @@
       }, {
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        withCredentials: true // 쿠키 포함
       });
       console.log('로그인 성공', response.data)
 
       const accessToken = response.data.data.accessToken;
-      const refreshToken = response.data.data.refreshToken;
+      // const refreshToken = response.data.data.refreshToken;
 
       console.log('✅ JWT Token 확인 테스트:', accessToken);
-      console.log('✅ Refresh Token 확인 테스트:', refreshToken);
+      // console.log('✅ Refresh Token 확인 테스트:', refreshToken);
 
-      await userStore.login(accessToken, refreshToken); 
+      await userStore.login(accessToken); 
 
       router.push('/home');  // 메인 홈으로 이동
 


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
새로고침해도 토큰이 사라지지 않는 문제를 해결하기 위해, 토큰 재발급 api를 백엔드와 연동하였습니다.
로그아웃 또한 store에서 진행하여 변경하였고 로그인 됐을 때 access_token 값만 잘받아와집니다
refresh-token은 cookie로 받고 있습니다
npm install jwt-decode 수행해야합니다!!

다만 문제점이, localhost:5173/으로 라우팅 시 조금 버벅이다가 다시 /home으로 변경되는데 이 점은 할 일 얼추 마무리 되면 고쳐보겠습니다..
## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 🌿 작업한 브랜치 (Working Branch)
> 예: `feature/게시글-작성`

- 현재 PR이 어떤 브랜치에서 작업되었는지 명시해주세요.
- feature/reissue

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- #63 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

## 📎 기타 참고 사항
- 코드 리뷰 중점적으로 봐줬으면 하는 부분
- 구현 중 고민된 점 등

## 📸 스크린샷 (선택)
UI 관련 변경사항이 있다면 스크린샷을 첨부해주세요.